### PR TITLE
cli: Renames yochu arguments by prefixing them with yochu-

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -50,13 +50,15 @@ func (viper *KochoConfiguration) newViperCreateFlags() swarmtypes.CreateFlags {
 		TemplateDir: viper.GetString("template-dir"),
 
 		Tags:             viper.GetString("tags"),
-		YochuVersion:     viper.GetString("yochu"),
-		FleetVersion:     viper.GetString("fleet-version"),
 		EtcdPeers:        viper.GetString("etcd-peers"),
-		EtcdVersion:      viper.GetString("etcd-version"),
 		EtcdDiscoveryURL: viper.GetString("etcd-discovery-url"),
-		DockerVersion:    viper.GetString("docker-version"),
 		ClusterSize:      viper.GetInt("cluster-size"),
+
+		// Yochu Flags
+		YochuVersion:  viper.GetString("yochu"),
+		FleetVersion:  viper.GetString("yochu-fleet-version"),
+		EtcdVersion:   viper.GetString("yochu-etcd-version"),
+		DockerVersion: viper.GetString("yochu-docker-version"),
 
 		// Provider interpreted
 		ImageURI:       viper.GetString("image"),

--- a/cli/create.go
+++ b/cli/create.go
@@ -33,19 +33,21 @@ func init() {
 func registerCreateFlags(flagset *pflag.FlagSet) {
 	flagset.String("type", "standalone", "type of the stack - there are primary, secondary and standalone stacks that form a cluster")
 	flagset.String("tags", "", "tags that should be added to fleetd of the swarm (eg --tags=cluster=core,disk=ssd)")
-	flagset.String("yochu", "", "version of Yochu to provision cluster nodes")
 	flagset.Int("cluster-size", 3, "number of nodes a cluster should have")
 	flagset.String("etcd-peers", "", "etcd peers a secondary swarm is connecting to")
 	flagset.String("etcd-discovery-url", "", "etcd discovery url for a secondary swarm is connecting to")
-	flagset.String("fleet-version", "v0.11.3-gs-2", "version to use when provisioning fleetd/fleetctl binaries")
-	flagset.String("etcd-version", "v2.1.2-gs-1", "version to use when provisioning etcd/etcdctl binaries")
 	flagset.String("template-dir", "templates", "directory to use for reading templates (see template-init command)")
-	flagset.String("docker-version", "1.6.2", "version to use when provisioning docker binaries")
 
 	awsEuWest1CoreOS := "ami-5f2f5528" // CoreOS Stable 681.2.0 (HVM eu-west-1)
 	flagset.String("image", awsEuWest1CoreOS, "image version that should be used to create a swarm")
 	flagset.String("certificate", "", "certificate ARN to use to create aws cluster")
 	flagset.String("machine-type", "m3.large", "machine type to use, e.g. m3.large for AWS")
+
+	// Yochu
+	flagset.String("yochu", "", "version of Yochu to provision cluster nodes")
+	flagset.String("yochu-docker-version", "1.6.2", "version to use when provisioning docker binaries")
+	flagset.String("yochu-fleet-version", "v0.11.3-gs-2", "version to use when provisioning fleetd/fleetctl binaries")
+	flagset.String("yochu-etcd-version", "v2.1.2-gs-1", "version to use when provisioning etcd/etcdctl binaries")
 
 	// AWS Provider specific
 	flagset.String("aws-keypair", "", "Keypair to use for AWS machines")

--- a/kocho.yml.example
+++ b/kocho.yml.example
@@ -17,9 +17,19 @@ certificate: <insert ssl certificate arn here>
 
 # For more options, see config.go
 
+## Yochu
+# Yochu is a provisioner which installs the specified versions of docker/etcd/fleet onto your coreos cluster
+# on startup. See https://github.com/giantswarm/yochu
+#
+# yochu-version: <version>
+# yochu-docker-version: <docker version>
+# yochu-fleet-version: <fleet version>
+# yochu-etcd-version: <etcd version>
+
 
 ## AWS
 # Default values for the AWS provider (could also be provided via --aws-* flags)
+#
 aws-vpc: <vpc name>
 aws-vpc-cidr: <vpc cidr>
 aws-keypair: <keypair name>


### PR DESCRIPTION
To make it easier to distinguish the Yochu arguments from Kochu's I prefixed them with `yochu-`.
