### PR TITLE
cli: Print errors when sending notifications fail

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/giantswarm/kocho/dns"
-	"github.com/giantswarm/kocho/notification"
 	"github.com/giantswarm/kocho/provider"
 	"github.com/giantswarm/kocho/swarm"
 )
@@ -109,7 +108,7 @@ func runCreate(args []string) (exit int) {
 	} else {
 		fmt.Printf("triggered swarm %s start. No DNS will be configured\n", name)
 	}
-	notification.SendMessage(projectVersion, projectBuild)
+	fireNotification()
 
 	return 0
 }

--- a/cli/destroy.go
+++ b/cli/destroy.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/giantswarm/kocho/dns"
-	"github.com/giantswarm/kocho/notification"
 	"github.com/giantswarm/kocho/provider"
 	"github.com/giantswarm/kocho/swarm"
 )
@@ -63,7 +62,7 @@ func runDestroy(args []string) (exit int) {
 	} else {
 		fmt.Printf("triggered swarm %s deletion\n", swarmName)
 	}
-	notification.SendMessage(projectVersion, projectBuild)
+	fireNotification()
 
 	return 0
 }

--- a/cli/dns.go
+++ b/cli/dns.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/kocho/dns"
-	"github.com/giantswarm/kocho/notification"
 	"github.com/giantswarm/kocho/swarm"
 )
 
@@ -47,7 +46,7 @@ func runDns(args []string) (exit int) {
 			return exitError("couldn't update dns entries", err)
 		}
 	}
-	notification.SendMessage(projectVersion, projectBuild)
+	fireNotification()
 
 	return 0
 }

--- a/cli/kill-instance.go
+++ b/cli/kill-instance.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/kocho/dns"
-	"github.com/giantswarm/kocho/notification"
 	"github.com/giantswarm/kocho/ssh"
 	"github.com/giantswarm/kocho/swarm"
 	"github.com/giantswarm/kocho/swarm/types"
@@ -79,7 +78,7 @@ func runKillInstance(args []string) (exit int) {
 		return exitError(errgo.Newf("DNS not changed. Couldn't find valid publid DNS name"))
 	}
 
-	notification.SendMessage(projectVersion, projectBuild)
+	fireNotification()
 
 	return 0
 }

--- a/cli/slack.go
+++ b/cli/slack.go
@@ -61,11 +61,29 @@ func runSlack(args []string) (exit int) {
 		}
 	case "test":
 		if err := notification.SendMessage(projectVersion, projectBuild); err != nil {
-			return exitError("failed to send test message")
+			if notification.IsNotConfigured(err) {
+				exitError("Notifications not configured. Use 'kocho slack init'")
+			} else if notification.IsInvalidConfiguration(err) {
+				exitError("Invalid configuration file:", err)
+			} else {
+				exitError("Failed to send message:", err)
+			}
+		} else {
+			fmt.Println("test message sent successfully.")
 		}
-
-		fmt.Println("test message sent successfully")
 	}
 
 	return 0
+}
+
+func fireNotification() {
+	if err := notification.SendMessage(projectVersion, projectBuild); err != nil {
+		if notification.IsNotConfigured(err) {
+			exitError("Notifications not configured. Use 'kocho slack init'")
+		} else if notification.IsInvalidConfiguration(err) {
+			exitError("Invalid configuration file: %v", err)
+		} else {
+			exitError("failed to send message: %v", err)
+		}
+	}
 }

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -13,3 +13,5 @@ based on your personal needs.
     "username": "username"
 }
 ```
+
+You can obtain a slack token using the Slack webinterface. You need to create a Bot integration.

--- a/notification/notification.go
+++ b/notification/notification.go
@@ -1,0 +1,18 @@
+package notification
+
+import (
+	"github.com/juju/errgo"
+)
+
+var (
+	ErrNotConfigured        = errgo.Newf("No notification receiver configured")
+	ErrInvalidConfiguration = errgo.Newf("Invalid configuration")
+)
+
+func IsNotConfigured(err error) bool {
+	return errgo.Cause(err) == ErrNotConfigured
+}
+
+func IsInvalidConfiguration(err error) bool {
+	return errgo.Cause(err) == ErrInvalidConfiguration
+}


### PR DESCRIPTION
Fixes bugs:
- `kocho slack init` failed if `~/.giantswarm/kocho/` didn't exist

Chores:
- Refactors `notification/` package to return proper errors and NOT print to stdout
