### PR TITLE
build: Build smaller docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM node
+FROM busybox:ubuntu-14.04
 
-# kocho
+MAINTAINER Stephan Zeissler <stephan@giantswarm.io>
+
 COPY kocho /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/kocho"]

--- a/kocho-docker.sh
+++ b/kocho-docker.sh
@@ -5,5 +5,8 @@ if [[ -z $IMAGE ]]; then
 fi
 
 docker run --rm -ti \
-  -v "$SSH_AUTH_SOCK:/tmp/ssh_auth_sock" -e "SSH_AUTH_SOCK=/tmp/ssh_auth_sock" \
+  -v "$SSH_AUTH_SOCK:/tmp/ssh_auth_sock" \
+  -e "SSH_AUTH_SOCK=/tmp/ssh_auth_sock" \
+  -v "$HOME/.giantswarm:/.giantswarm" \
+  -v "$(pwd):$(pwd)" -w "$(pwd)" \
   ${IMAGE} $*


### PR DESCRIPTION
* Use `busybox` instead of `node` (alpine doesn't work because of mulibc thingy)
* Use golang 1.5 to build the binary
* Default to linux to prevent accidentially building a docker image with a darwin binary

```
$ docker images | grep kocho
registry.giantswarm.io/giantswarm/kocho            master-2016-02-17-12-04-40   e026b8dfbcb3        About a minute ago   24.95 MB
```

