### PR TITLE
Use right name for the environment variable

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -67,7 +67,7 @@ To make Slack notifications work, put the slack configuration into `~/.giantswar
 Further, make sure you have your AWS credentials in your environment.
 
 ```
-export AWS_SECRET_ACCESS_KEY=<aws secret access key>
+export AWS_SECRET_KEY=<aws secret access key>
 export AWS_ACCESS_KEY=<aws access key>
 ```
 


### PR DESCRIPTION
I was using `AWS_SECRET_ACCESS_KEY` following the documentation. I got the following error described in: https://github.com/giantswarm/kocho/issues/47

If you use `AWS_SECRET_KEY, it works.

ping @zeisss